### PR TITLE
Fixed min/max definition and other macros as well

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -85,6 +85,33 @@ void loop( void ) ;
 #include "wiring_shift.h"
 #include "WInterrupts.h"
 
+// undefine stdlib's abs if encountered
+#ifdef abs
+#undef abs
+#endif // abs
+
+#define min(a,b) ((a)<(b)?(a):(b))
+#define max(a,b) ((a)>(b)?(a):(b))
+#define abs(x) ((x)>0?(x):-(x))
+#define constrain(amt,low,high) ((amt)<(low)?(low):((amt)>(high)?(high):(amt)))
+#define round(x)     ((x)>=0?(long)((x)+0.5):(long)((x)-0.5))
+#define radians(deg) ((deg)*DEG_TO_RAD)
+#define degrees(rad) ((rad)*RAD_TO_DEG)
+#define sq(x) ((x)*(x))
+
+#define interrupts() __enable_irq()
+#define noInterrupts() __disable_irq()
+
+#define lowByte(w) ((uint8_t) ((w) & 0xff))
+#define highByte(w) ((uint8_t) ((w) >> 8))
+
+#define bitRead(value, bit) (((value) >> (bit)) & 0x01)
+#define bitSet(value, bit) ((value) |= (1UL << (bit)))
+#define bitClear(value, bit) ((value) &= ~(1UL << (bit)))
+#define bitWrite(value, bit, bitvalue) (bitvalue ? bitSet(value, bit) : bitClear(value, bit))
+
+#define bit(b) (1UL << (b))
+
 // USB Device
 #include "USB/USBDesc.h"
 #include "USB/USBCore.h"

--- a/cores/arduino/USB/USBCore.cpp
+++ b/cores/arduino/USB/USBCore.cpp
@@ -16,12 +16,7 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <stdint.h>
-
-#include "sam.h"
-#include "wiring_constants.h"
+#include "../Arduino.h"
 #include "USBCore.h"
 #include "USB/USB_device.h"   // needed for USB PID define
 #include "USBDesc.h"

--- a/cores/arduino/wiring_constants.h
+++ b/cores/arduino/wiring_constants.h
@@ -56,41 +56,6 @@ enum BitOrder {
 //#define DEFAULT 1
 //#define EXTERNAL 0
 
-// undefine stdlib's abs if encountered
-
-//#ifdef abs
-//#undef abs
-//#endif // abs
-
-
-#ifndef min
-#define min(a,b) ((a)<(b)?(a):(b))
-#endif // min
-
-#ifndef max
-#define max(a,b) ((a)>(b)?(a):(b))
-#endif // max
-
-//#define abs(x) ((x)>0?(x):-(x))
-#define constrain(amt,low,high) ((amt)<(low)?(low):((amt)>(high)?(high):(amt)))
-#define round(x)     ((x)>=0?(long)((x)+0.5):(long)((x)-0.5))
-#define radians(deg) ((deg)*DEG_TO_RAD)
-#define degrees(rad) ((rad)*RAD_TO_DEG)
-#define sq(x) ((x)*(x))
-
-#define interrupts() __enable_irq()
-#define noInterrupts() __disable_irq()
-
-#define lowByte(w) ((uint8_t) ((w) & 0xff))
-#define highByte(w) ((uint8_t) ((w) >> 8))
-
-#define bitRead(value, bit) (((value) >> (bit)) & 0x01)
-#define bitSet(value, bit) ((value) |= (1UL << (bit)))
-#define bitClear(value, bit) ((value) &= ~(1UL << (bit)))
-#define bitWrite(value, bit, bitvalue) (bitvalue ? bitSet(value, bit) : bitClear(value, bit))
-
-#define bit(b) (1UL << (b))
-
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus


### PR DESCRIPTION
It seems that

   #include <stdint.h>

is able to undef "min" and "max" previously defined. With this
commit we make sure that they are defined as last.

Fix #10